### PR TITLE
Fix message endpoint and enhance logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ following settings in the instance dialog:
 
 ## States
 
-- `roomID` (number): ID of the room to send messages to.
+ - `roomID` (string): Talk room token to send messages to.
 - `text` (string): When this state is changed, the adapter posts the new value as a message to the configured room.
 
 ## Usage
 
 Update the `text` state from scripts or other adapters to send a message.
+Messages are sent via the Nextcloud Talk API endpoint `/ocs/v2.php/apps/spreed/api/v1/chat/{token}`.
 
 ## Changelog
 

--- a/main.js
+++ b/main.js
@@ -43,16 +43,27 @@ class NextcloudTalk extends utils.Adapter {
         const server = this.config.server;
         const username = this.config.username;
         const token = this.config.token;
-        const url = `${server}/ocs/v2.php/apps/spreed/api/v4/rooms/${roomId}/message`;
-        await axios.post(url, { message: text }, {
-            headers: {
-                'OCS-APIRequest': 'true'
-            },
-            auth: {
-                username: username,
-                password: token
+        const url = `${server}/ocs/v2.php/apps/spreed/api/v1/chat/${roomId}`;
+        const body = { message: text, actorDisplayName: '', referenceId: '', replyTo: 0, silent: false };
+        this.log.debug(`Sending POST request to ${url} with body: ${JSON.stringify(body)}`);
+        try {
+            await axios.post(url, body, {
+                headers: {
+                    'OCS-APIRequest': 'true'
+                },
+                auth: {
+                    username: username,
+                    password: token
+                }
+            });
+        } catch (error) {
+            if (error.response) {
+                this.log.error(`POST ${error.response.config.url} failed with ${error.response.status}: ${JSON.stringify(error.response.data)}`);
+            } else {
+                this.log.error(`Request error: ${error.message}`);
             }
-        });
+            throw error;
+        }
     }
 }
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -8,8 +8,8 @@ describe('NextcloudTalk adapter', () => {
         adapter.config = { server: 'https://nc', username: 'user', token: 'token' };
         await adapter.sendMessage(5, 'hello');
         expect(axios.post).toHaveBeenCalledWith(
-            'https://nc/ocs/v2.php/apps/spreed/api/v4/rooms/5/message',
-            { message: 'hello' },
+            'https://nc/ocs/v2.php/apps/spreed/api/v1/chat/5',
+            { message: 'hello', actorDisplayName: '', referenceId: '', replyTo: 0, silent: false },
             expect.objectContaining({ auth: { username: 'user', password: 'token' } })
         );
     });


### PR DESCRIPTION
## Summary
- send messages to `/ocs/v2.php/apps/spreed/api/v1/chat/{token}`
- include required fields in POST body
- improve error logging and mention endpoint in README
- update unit test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843269c53c08333ba693aa7c5363e6d