### PR TITLE
Fix dependencies and license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright (c) 2025 Rello
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 

--- a/README.md
+++ b/README.md
@@ -28,5 +28,7 @@ Messages are sent via the Nextcloud Talk API endpoint `/ocs/v2.php/apps/spreed/a
 
 ## License
 
+Copyright (c) 2025 Rello
+
 MIT
 

--- a/io-package.json
+++ b/io-package.json
@@ -68,7 +68,8 @@
     },
     "type": "messaging",
     "dependencies": [
-      {"js-controller": ">=6.0.0"}
+      {"js-controller": ">=6.0.0"},
+      {"admin": ">=6.17.14"}
     ]
   },
   "native": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@iobroker/adapter-core": "^3.2.2",
+        "@iobroker/adapter-core": "^3.2.3",
         "axios": "^1.6.0"
       },
       "devDependencies": {
-        "@iobroker/testing": "4.1.3",
+        "@iobroker/testing": "^4.1.3",
         "jest": "^29.7.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "type": "commonjs",
   "dependencies": {
-    "@iobroker/adapter-core": "^3.2.2",
+    "@iobroker/adapter-core": "^3.2.3",
     "axios": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- bump `@iobroker/adapter-core` to 3.2.3
- add admin dependency in `io-package.json`
- note copyright year in README and LICENSE

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d039a083483338fef5926f3eeecb4