### PR TITLE
Add axios request timeout

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ if (process.env.NODE_ENV === 'test') {
     utils = require('@iobroker/adapter-core');
 }
 const axios = require('axios');
+const AXIOS_TIMEOUT = 10000;
 
 class NextcloudTalk extends utils.Adapter {
     constructor(options) {
@@ -62,6 +63,7 @@ class NextcloudTalk extends utils.Adapter {
                     username: username,
                     password: token,
                 },
+                timeout: AXIOS_TIMEOUT,
             });
         } catch (error) {
             if (error.response) {

--- a/main.test.js
+++ b/main.test.js
@@ -20,8 +20,6 @@ describe('module to test => function to test', () => {
         const result = 5;
         // assign result a value from functionToTest
         expect(result).to.equal(expected);
-        // or using the should() syntax
-        result.should.equal(expected);
     });
     // ... more tests => it
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -12,7 +12,7 @@ describe('NextcloudTalk adapter', () => {
         expect(axios.post).toHaveBeenCalledWith(
             'https://nc/ocs/v2.php/apps/spreed/api/v1/chat/5',
             { message: 'hello', actorDisplayName: '', referenceId: '', replyTo: 0, silent: false },
-            expect.objectContaining({ auth: { username: 'user', password: 'token' } })
+            expect.objectContaining({ auth: { username: 'user', password: 'token' }, timeout: 10000 })
         );
     });
 });


### PR DESCRIPTION
## Summary
- prevent hanging adapter by adding 10s timeout to axios calls
- verify timeout handling in unit tests
- clean up placeholder test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897770f9bc88333ad474c6eb10772e9